### PR TITLE
Add geocoding-based route creation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ streamlit-folium
 folium
 plotly
 pandas
+requests


### PR DESCRIPTION
## Summary
- add `requests` requirement
- implement address geocoding and distance calculation
- track selected geocoded addresses in session state
- search addresses when planning routes and display results
- compute distance, show a preview map and auto-fill route data

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile Transporte.py`

------
https://chatgpt.com/codex/tasks/task_e_68826c9acda48327973ed54d4ea74a33